### PR TITLE
Proposal: Feature - AbstractViewOwner

### DIFF
--- a/src/snap/view/CustomViewOwner.java
+++ b/src/snap/view/CustomViewOwner.java
@@ -1,0 +1,62 @@
+package snap.view;
+
+/**
+ * Helper class to create custom ViewOwners with novel interpretations.
+ */
+public abstract class CustomViewOwner extends ViewOwner {
+
+    /**
+     * Creates the top level view for this owner.
+     * <br><br>
+     * API Note: If you want the vanilla interaction of this class, return {@code default_createUI();}
+     */
+    @Override
+    abstract protected View createUI();
+
+    /**
+     * Initializes the UI panel.
+     * <br><br>
+     * API Note: If you want the vanilla interaction of this class, return {@code default_initUI();}
+     */
+    @Override
+    abstract protected void initUI();
+
+    /**
+     * Reset UI controls.
+     * <br><br>
+     * API Note: If you want the vanilla interaction of this class, return {@code default_resetUI();}
+     */
+    @Override
+    abstract protected void resetUI();
+
+    /**
+     * Respond to UI controls.
+     * <br><br>
+     * API Note: If you want the vanilla interaction of this class, return {@code default_respondUI(ViewEvent);}
+     * @param anEvent Any event that has been caught by this ViewOwner.
+     */
+    @Override
+    abstract protected void respondUI(ViewEvent anEvent);
+
+    /**
+     * Default implementation of {@link ViewOwner#createUI()}
+     * @return View loaded from snp file of the same name as the class.
+     */
+    final protected View default_createUI() {return super.createUI();}
+
+    /**
+     * Default implementation of {@link ViewOwner#initUI()}
+     */
+    final protected void default_initUI() {super.initUI();}
+
+    /**
+     * Default implementation of {@link ViewOwner#resetUI()}
+     */
+    final protected void default_resetUI() {super.resetUI();}
+
+    /**
+     * Default implementation of {@link ViewOwner#respondUI(ViewEvent)}
+     * @param anEvent An event which has been captured by the view.
+     */
+    final protected void default_respondUI(ViewEvent anEvent) {super.respondUI(anEvent);}
+}


### PR DESCRIPTION
This pull request is an request for discussion. 

I would like something similar to this in the project to assist with on-boarding people who are not familiar with the format (including myself). Right now the ViewOwner class is difficult to tell which methods are meant to be overridden, and which ones are not, at a glance. The starting out wiki page helps with this, but the API contract should reflect this as well.

I can see several different ways that it could be done.

1.  Including an abstract class that very pointedly requires the user to override the important methods so that they can separate the modifiable portions from the non-modifiable. This can be done in two different ways:
      1. Refactor `ViewOwner` into `AbstractViewOwner`, make the major methods abstract there, and then provide default implementations in `ViewOwner` class (or `DefaultViewOwner` or something). The pluses with this way is that all existing code would continue to work, but that most references to `ViewOwner` should be refactored to `AbstractViewOwner`
      2. Create an abstract class that extends `ViewOwner` and make the modifiable methods abstract in that class. This is what I have done in the provided code, but I would recommend a different classname, because `AbstractViewOwner` implies that it is the parent of `ViewOwner`, rather than the other way around. This way requires no refactoring at all, but would have your documentation directed towards this new abstract class, rather than `ViewOwner ` directly. It also goes against common convention, but isn't a big deal because it doesn't break anything.
2. Some sort of Interface. I did try to think up a proper example for this here, but I couldn't think of one that would work easy off the top of my head. An Interface would definitely require refactoring, but would work in a way similar to `1.i.` in the previous statement for the end user.

I have no hard demands one way or another, but this was something that got me a little stumped at the start, and if it wasn't for the how-to-guide, I would not have been able to guess this from the code. I personally would prefer that the main ViewOwner class was abstract (especially since this library expects you to extend it), but that default implementations were available in a default class or method. That said, the code example I've provided works as is with no changes required, but it doesn't match the Java pattern very well. Give it a different name and it might be totally fine though.

Let me know what you think, these are just some starter ideas I came up with, but so long as there is an easy way to determine the API expectations, I'm all for it.