### PR TITLE
Adding Javadoc and sources jar to build/publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,14 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+    withJavadocJar()
+    withSourcesJar()
+}
+
+sourcesJar {
+    duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 }
 
 repositories { mavenCentral() }
@@ -26,7 +34,25 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << "-parameters"
 }
 
+tasks.publish.doFirst() {
+    def user = System.getenv("GITHUB_USER")
+    def pw = System.getenv("GITHUB_TOKEN")
+    println "Publish start user:$user"
+}
+
 publishing {
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = "https://maven.pkg.github.com/reportmill/SnapKit"
+            credentials {
+                username = System.getenv("GITHUB_USER")
+                password = System.getenv("GITHUB_TOKEN")
+                println "Publish user: username=$username"
+            }
+        }
+    }
 
     publications {
         gpr(MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,6 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
     withJavadocJar()
     withSourcesJar()
 }


### PR DESCRIPTION
Super simple addition to the build script to build the javadoc and sources. This one doesn't need to be added if you do not want it, but I am running it on my local copy so that I don't have to keep the SnapKit project open all the time.

- Add generation of Javadoc and sources jars so that they can be included at publish time.
- Fixed a Gradle duplications problem with building the sources jar.