### PR TITLE
Added a method to retrieve tabs directly from TabView.

### DIFF
--- a/src/snap/view/TabView.java
+++ b/src/snap/view/TabView.java
@@ -176,6 +176,11 @@ public class TabView extends ParentView implements Selectable<Tab>, ViewHost {
     public int getTabCount()  { return _tabBar.getTabCount(); }
 
     /**
+     * Returns the tabs currently attached to the TabView.
+     */
+    public List<Tab> getTabs()  { return _tabBar.getTabs(); }
+
+    /**
      * Returns the tab at given index.
      */
     public Tab getTab(int anIndex)  { return _tabBar.getTab(anIndex); }


### PR DESCRIPTION
Pretty straight forward, its a missing compliment to the add and remove fields. In order to do a comparison of tabs, the only option is to use count and a for loop with get, would rather just pass the getTabs method up a level. More flexibility, and completes the add, remove, get options.